### PR TITLE
added destroy dependent gears

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :bookings
-  has_many :gears
+  has_many :gears, dependent: :destroy
 
 end


### PR DESCRIPTION
Fixed issue where bookings were not destroyed and reappeared after new gear was added.